### PR TITLE
Enable paste

### DIFF
--- a/packages/niivue-desktop/src/main/utils/menu.ts
+++ b/packages/niivue-desktop/src/main/utils/menu.ts
@@ -361,6 +361,13 @@ export const createMenu = (win: Electron.BrowserWindow): Electron.Menu => {
       label: 'Edit',
       submenu: [
         {
+          label: 'Paste',
+          accelerator: 'CmdOrCtrl+V',
+          click: (): void => {
+            win.webContents.paste()
+          }
+        },
+        {
           label: 'Preferences...',
           accelerator: 'CmdOrCtrl+,',
           click: (): void => {


### PR DESCRIPTION
List of fixed issues (if they exist):

- Enable copying and pasting on Macs
